### PR TITLE
Change PropTypes imports to import from prop-types package

### DIFF
--- a/src/Button/Button.js
+++ b/src/Button/Button.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import createStyledComponent from '../utils/createStyledComponent';
 import * as styles from './styles';
 import { commonStyle, tooltipStyle } from './styles/common';

--- a/src/Container/index.js
+++ b/src/Container/index.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { ThemeProvider } from 'styled-components';
 import { getTheme } from '../utils/theme';
 import { MainContainerWrapper, ContainerWrapper } from './styles';

--- a/src/ContextMenu/ContextMenu.js
+++ b/src/ContextMenu/ContextMenu.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import createStyledComponent from '../utils/createStyledComponent';
 import styles from './styles/index';
 

--- a/src/Dialog/Dialog.js
+++ b/src/Dialog/Dialog.js
@@ -1,4 +1,5 @@
-import React, { PureComponent, Component, PropTypes } from 'react';
+import React, { PureComponent, Component } from 'react';
+import PropTypes from 'prop-types';
 import createStyledComponent from '../utils/createStyledComponent';
 import * as styles from './styles';
 import Button from '../Button';

--- a/src/Editor/Editor.js
+++ b/src/Editor/Editor.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import CodeMirror from 'codemirror';
 import { defaultStyle, themedStyle } from './styles';

--- a/src/Form/Form.js
+++ b/src/Form/Form.js
@@ -1,4 +1,5 @@
-import React, { PureComponent, Component, PropTypes } from 'react';
+import React, { PureComponent, Component } from 'react';
+import PropTypes from 'prop-types';
 import JSONSchemaForm from 'react-jsonschema-form';
 import createStyledComponent from '../utils/createStyledComponent';
 import styles from './styles';

--- a/src/Notification/Notification.js
+++ b/src/Notification/Notification.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import CloseIcon from 'react-icons/lib/md/close';
 import WarningIcon from 'react-icons/lib/md/warning';
 import ErrorIcon from 'react-icons/lib/md/error';

--- a/src/SegmentedControl/SegmentedControl.js
+++ b/src/SegmentedControl/SegmentedControl.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import createStyledComponent from '../utils/createStyledComponent';
 import styles from './styles';
 

--- a/src/Select/Select.js
+++ b/src/Select/Select.js
@@ -1,4 +1,5 @@
-import React, { PureComponent, Component, PropTypes } from 'react';
+import React, { PureComponent, Component } from 'react';
+import PropTypes from 'prop-types';
 import ReactSelect from 'react-select';
 import createStyledComponent from '../utils/createStyledComponent';
 import styles from './styles';

--- a/src/Slider/Slider.js
+++ b/src/Slider/Slider.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import createStyledComponent from '../utils/createStyledComponent';
 import * as styles from './styles';
 import { containerStyle } from './styles/common';

--- a/src/Tabs/Tabs.js
+++ b/src/Tabs/Tabs.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import TabsHeader from './TabsHeader';
 import { TabsContainer } from './styles/common';
 

--- a/src/Tabs/TabsHeader.js
+++ b/src/Tabs/TabsHeader.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import createStyledComponent from '../utils/createStyledComponent';
 import * as styles from './styles';
 


### PR DESCRIPTION
Resolves a deprecation warning due to `PropTypes` being removed from the main `react` package in the next upcoming major release.

https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html#migrating-from-react.proptypes